### PR TITLE
fix: latitude clipping

### DIFF
--- a/quadbin/utils.py
+++ b/quadbin/utils.py
@@ -2,7 +2,7 @@ import math
 
 MAX_LONGITUDE = 180.0
 MIN_LONGITUDE = -MAX_LONGITUDE
-MAX_LATITUDE = 85.051129
+MAX_LATITUDE = 89.0
 MIN_LATITUDE = -MAX_LATITUDE
 
 UP = 0
@@ -136,7 +136,8 @@ def point_to_tile_fraction(longitude, latitude, resolution):
     z2 = 1 << z
     sinlat = math.sin(latitude * math.pi / 180.0)
     x = z2 * (longitude / 360.0 + 0.5)
-    y = z2 * (0.5 - 0.25 * math.log((1 + sinlat) / (1 - sinlat)) / math.pi)
+    yfraction = 0.5 - 0.25 * math.log((1 + sinlat) / (1 - sinlat)) / math.pi
+    y = clip_number(z2 * yfraction, 0, z2 - 1)
 
     # Wrap Tile x
     x = x % z2

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -48,6 +48,13 @@ def test_cell_to_point():
 
 def test_point_to_cell():
     assert quadbin.point_to_cell(33.75, -11.178401873711776, 4) == 5209574053332910079
+    assert quadbin.point_to_cell(0.0, 85.05112877980659, 26) == 5306366260949286912
+    assert quadbin.point_to_cell(0.0, 88, 26) == 5306366260949286912
+    assert quadbin.point_to_cell(0.0, 90, 26) == 5306366260949286912
+    assert quadbin.point_to_cell(0.0, -85.05112877980659, 26) == 5309368660700867242
+    assert quadbin.point_to_cell(0.0, -88, 26) == 5309368660700867242
+    assert quadbin.point_to_cell(0.0, -90, 26) == 5309368660700867242
+
     with pytest.raises(ValueError, match="Invalid resolution"):
         assert quadbin.point_to_cell(33.75, -11.178401873711776, -1)
     with pytest.raises(ValueError, match="Invalid resolution"):


### PR DESCRIPTION
Since the latitude to tile y formula is unstable near the limit latitude (85.05112877980659), the latitude was being clipped with a slightler smaller value than the limit (85.051129), but this didn't prevent that latitudes near it were assigned to incorrect tile y values.

To fix this, the clipping now occurs after computing the y. A clipping of the input latitude to -89, 89 is maintained to avoid the formula failing with a division by zero near or at latitude 90. 